### PR TITLE
Fix timing

### DIFF
--- a/stm32f4xx_it.c
+++ b/stm32f4xx_it.c
@@ -134,8 +134,8 @@ void EXTI0_IRQHandler(void) {
 	    (enablestatus != (uint32_t)RESET)) {
 		/* Do stuff on trigger */
 
-		/* Wait 10 NOPs, until the ADDR is ready in the bus */
-		REP(1,0,asm("NOP"););
+		/* Wait 8 NOPs, until the ADDR is ready in the bus */
+		REP(0,8,asm("NOP"););
 		/* Read ADDR from the bus */
 		addr = ADDR_IN;
 		


### PR DESCRIPTION
Not sure this is the proper solution, but I had some games not running or crashing at some point with 10 NOPs here (Super Mario Land, Final Fantasy Legend 2...), they're running fine with 8 NOPs instead.
